### PR TITLE
Allow a comma as decimal separator

### DIFF
--- a/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
+++ b/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
@@ -38,7 +38,7 @@ export class DigitOnlyDirective {
       (e.key === 'c' && e.metaKey === true) || // Allow: Cmd+C (Mac)
       (e.key === 'v' && e.metaKey === true) || // Allow: Cmd+V (Mac)
       (e.key === 'x' && e.metaKey === true) || // Allow: Cmd+X (Mac)
-      (this.decimal && e.key === '.' && this.decimalCounter < 1) // Allow: only one decimal point
+      (this.decimal && (e.key === '.' || e.key === ',') && this.decimalCounter < 1) // Allow: only one decimal point
     ) {
       // let it happen, don't do anything
       return;
@@ -55,6 +55,7 @@ export class DigitOnlyDirective {
       return;
     } else {
       this.decimalCounter = this.el.nativeElement.value.split('.').length - 1;
+      this.decimalCounter += this.el.nativeElement.value.split(',').length - 1;
     }
   }
 
@@ -99,6 +100,6 @@ export class DigitOnlyDirective {
   }
 
   private isValidDecimal(string: string): boolean {
-    return string.split('.').length <= 2;
+    return (string.split('.').length + string.split(',').length) <= 2;
   }
 }

--- a/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
+++ b/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
@@ -19,7 +19,8 @@ export class DigitOnlyDirective {
     'Copy',
     'Paste'
   ];
-  @Input() decimal?= false;
+  @Input() decimal ? = false;
+  @Input() decimalSeparator ? = '.';
   inputElement: HTMLInputElement;
 
   constructor(public el: ElementRef) {
@@ -38,7 +39,7 @@ export class DigitOnlyDirective {
       (e.key === 'c' && e.metaKey === true) || // Allow: Cmd+C (Mac)
       (e.key === 'v' && e.metaKey === true) || // Allow: Cmd+V (Mac)
       (e.key === 'x' && e.metaKey === true) || // Allow: Cmd+X (Mac)
-      (this.decimal && (e.key === '.' || e.key === ',') && this.decimalCounter < 1) // Allow: only one decimal point
+      (this.decimal && (e.key === this.decimalSeparator) && this.decimalCounter < 1) // Allow: only one decimal point
     ) {
       // let it happen, don't do anything
       return;
@@ -54,8 +55,7 @@ export class DigitOnlyDirective {
     if (!this.decimal) {
       return;
     } else {
-      this.decimalCounter = this.el.nativeElement.value.split('.').length - 1;
-      this.decimalCounter += this.el.nativeElement.value.split(',').length - 1;
+      this.decimalCounter = this.el.nativeElement.value.split(this.decimalSeparator).length - 1;
     }
   }
 
@@ -86,7 +86,8 @@ export class DigitOnlyDirective {
   private sanatizeInput(input: string): string {
     let result = '';
     if (this.decimal && this.isValidDecimal(input)) {
-      result = input.replace(/[^0-9.]/g, '');
+      const regex = new RegExp(`[^0-9${this.decimalSeparator}]`, 'g');
+      result = input.replace(regex, '');
     } else {
       result = input.replace(/[^0-9]/g, '');
     }
@@ -100,6 +101,6 @@ export class DigitOnlyDirective {
   }
 
   private isValidDecimal(string: string): boolean {
-    return (string.split('.').length + string.split(',').length) <= 2;
+    return string.split(this.decimalSeparator).length <= 2;
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,16 +4,30 @@
   <label for="digit-only">Digit Only input box</label>
   <input id="digit-only" type="text" digitOnly placeholder="000" />
 
-  <label for="digit-only">
+  <label for="digit-only-decimal">
     Digit Only input box that allows a <i>decimal point</i>
   </label>
   <input
-    id="digit-only"
+    id="digit-only-decimal"
     type="text"
     digitOnly
     decimal="true"
     placeholder="0.00"
     pattern="[0-9]+([\.][0-9]+)?"
+  />
+
+  <label for="digit-only-decimal-comma">
+    Digit Only input box that allows a <i>decimal point</i> using
+    <strong>a comma as the separator</strong>
+  </label>
+  <input
+    id="digit-only-decimal-comma"
+    type="text"
+    digitOnly
+    decimal="true"
+    decimalSeparator=","
+    placeholder="0,00"
+    pattern="[0-9]+([,][0-9]+)?"
   />
 
   <label for="digit-only-with-max-length"
@@ -57,11 +71,12 @@
     decimal="true"
   />
 
-  <label for="text">regular text input</label>
-  <input id="text" type="text" placeholder="regular text input" />
+  <label for="regular-text">regular text input</label>
+  <input id="regular-text" type="text" placeholder="regular text input" />
 
-  <label for="text">text input with pattern attribute</label>
+  <label for="text-with-pattern">text input with pattern attribute</label>
   <input
+    id="text-with-pattern"
     type="text"
     pattern="[0-9]*"
     maxlength="3"


### PR DESCRIPTION
A lot countries are using a comma as decimal separator. With this fix you can use a comma as well.

https://en.wikipedia.org/wiki/Decimal_separator