### PR TITLE
feat(digit-only): allow pattern binding

### DIFF
--- a/cypress/integration/patterns.spec.ts
+++ b/cypress/integration/patterns.spec.ts
@@ -1,0 +1,39 @@
+describe('Patterns', () => {
+  beforeEach(() => {
+    cy.visit('');
+  });
+
+  it('should change pattern on runtime using the binding', () => {
+    cy.get('#change-pattern')
+      .clear()
+      .type('^[0-9]{1,5}$', { parseSpecialCharSequences: false });
+
+    cy.get('#pattern-binding')
+      .type('112345556')
+      .should('have.value', '11234')
+      .clear();
+
+    cy.get('#change-pattern')
+      .clear()
+      .type('^[1-2]+$');
+
+    cy.get('#pattern-binding')
+      .type('515.26789.2')
+      .should('have.value', '122')
+      .clear();
+
+    cy.get('#change-pattern').clear()
+
+    cy.get('#pattern-binding')
+      .type('112345556')
+      .should('have.value', '112345556')
+      .clear();
+  });
+
+  it('if pattern is empty, should allow any numeric input', () => {
+    cy.get('#pattern-binding')
+      .type('112345556')
+      .should('have.value', '112345556')
+      .clear();
+  });
+});

--- a/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
+++ b/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
@@ -1,9 +1,16 @@
-import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  Input,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 
 @Directive({
   selector: '[digitOnly]',
 })
-export class DigitOnlyDirective {
+export class DigitOnlyDirective implements OnChanges {
   private hasDecimalPoint = false;
   private navigationKeys = [
     'Backspace',
@@ -19,15 +26,20 @@ export class DigitOnlyDirective {
     'Copy',
     'Paste',
   ];
+  private regex: RegExp;
+  @Input() pattern?: string | RegExp;
   @Input() decimal? = false;
   @Input() decimalSeparator? = '.';
   inputElement: HTMLInputElement;
-  regex: RegExp;
+
 
   constructor(public el: ElementRef) {
     this.inputElement = el.nativeElement;
-    if (this.inputElement.pattern) {
-      this.regex = new RegExp(this.inputElement.pattern);
+  }
+
+  ngOnChanges({ pattern }: SimpleChanges): void {
+    if (pattern) {
+      this.regex = this.pattern ? RegExp(this.pattern) : null;
     }
   }
 
@@ -151,7 +163,7 @@ export class DigitOnlyDirective {
     return selection
       ? oldValue.replace(selection, key)
       : oldValue.substring(0, selectionStart) +
-          key +
-          oldValue.substring(selectionStart);
+      key +
+      oldValue.substring(selectionStart);
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,7 +13,7 @@
     digitOnly
     decimal="true"
     placeholder="0.00"
-    pattern="[0-9]+([\.][0-9]+)?"
+    [pattern]="pattern"
   />
 
   <label for="digit-only-decimal-comma">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,7 +13,7 @@
     digitOnly
     decimal="true"
     placeholder="0.00"
-    [pattern]="pattern"
+    [pattern]="decimalPattern"
   />
 
   <label for="digit-only-decimal-comma">
@@ -86,6 +86,25 @@
     title="3 digits code"
     placeholder="000"
   />
+  
+  <label for="pattern-binding">text input with pattern binding</label>
+  <input
+    id="pattern-binding"
+    type="text"
+    [pattern]="pattern"
+    name="pattern-binding"
+    title="3 digits code"
+    [placeholder]="pattern"
+    digitOnly
+  />
+  <input
+    id="change-pattern"
+    type="text"
+    [(ngModel)]="pattern"
+    name="change-pattern"
+    placeholder="Type your pattern"
+  />
+  
 
   <label for="currency">Digit Only input only allows two decimal places</label>
   <input

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,7 +7,9 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   amount: string;
-  pattern = '[0-9]+([\.][0-9]+)?';
+  decimalPattern = new RegExp('[0-9]+([\.][0-9]+)?');
+
+  pattern = '';
 
   watchAmountValue() {
     const value = Number(this.amount);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,9 +7,11 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   amount: string;
+  pattern = '[0-9]+([\.][0-9]+)?';
+
   watchAmountValue() {
     const value = Number(this.amount);
     this.amount = value.toFixed(2);
-    console.log(this.amount)
+    console.log(this.amount);
   }
 }


### PR DESCRIPTION
Allow to use pattern as a binding. It allows to change the pattern using an observable (`[pattern]="patterns$ | async"`) or simply change pattern on runtime (`this.pattern = otherPattern`).