### PR TITLE
feat(digit-only): add min & max

### DIFF
--- a/cypress/integration/min-max.spec.ts
+++ b/cypress/integration/min-max.spec.ts
@@ -1,0 +1,72 @@
+describe('Min max', () => {
+  beforeEach(() => {
+    cy.visit('');
+  });
+
+  it('should only numbers between 0 and 100', () => {
+    cy.get('#digit-only-min-max')
+      .type('0')
+      .should('have.value', '0')
+      .type('5')
+      .should('have.value', '05')
+      .type('0')
+      .should('have.value', '050')
+      .type('0')
+      .should('have.value', '050')
+      .clear()
+      .type('100')
+      .should('have.value', '100')
+      .type('0')
+      .should('have.value', '100')
+      .clear()
+      .type('201')
+      .should('have.value', '20')
+      .clear();
+  });
+
+  it('should change limits on runtime', () => {
+    cy.get('#min')
+      .clear()
+      .type('5')
+
+    cy.get('#max')
+      .clear()
+      .type('10')
+
+    // number must be >= 5 and <= 10
+    cy.get('#digit-only-min-max-binding')
+      .type('0')
+      .should('have.value', '')
+      .type('5')
+      .should('have.value', '5')
+      .type('0')
+      .should('have.value', '5')
+      .clear()
+      .type('100')
+      .should('have.value', '')
+      .clear();
+
+    cy.get('#min')
+      .clear()
+      .type('8')
+
+    cy.get('#max')
+      .clear()
+      .type('850')
+
+    // number must be >= 8 and <= 850
+    cy.get('#digit-only-min-max-binding')
+      .type('0')
+      .should('have.value', '')
+      .type('5')
+      .should('have.value', '')
+      .type('0')
+      .should('have.value', '')
+      .clear()
+      .type('850')
+      .should('have.value', '850')
+      .type('0')
+      .should('have.value', '850')
+      .clear();
+  });
+});

--- a/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
+++ b/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+import { Directive, ElementRef, HostListener, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 @Directive({
   selector: '[digitOnly]',
 })
-export class DigitOnlyDirective {
+export class DigitOnlyDirective implements OnChanges {
   private hasDecimalPoint = false;
   private navigationKeys = [
     'Backspace',
@@ -19,8 +19,10 @@ export class DigitOnlyDirective {
     'Copy',
     'Paste',
   ];
-  @Input() decimal? = false;
-  @Input() decimalSeparator? = '.';
+  @Input() decimal = false;
+  @Input() decimalSeparator = '.';
+  @Input() min = -Infinity;
+  @Input() max = Infinity;
   inputElement: HTMLInputElement;
   regex: RegExp;
 
@@ -28,6 +30,18 @@ export class DigitOnlyDirective {
     this.inputElement = el.nativeElement;
     if (this.inputElement.pattern) {
       this.regex = new RegExp(this.inputElement.pattern);
+    }
+  }
+
+  ngOnChanges({ min, max }: SimpleChanges): void {
+    if (min) {
+      const maybeMin = Number(this.min);
+      this.min = isNaN(maybeMin) ? -Infinity : maybeMin;
+    }
+
+    if (max) {
+      const maybeMax = Number(this.max);
+      this.max = isNaN(maybeMax) ? Infinity : maybeMax;
     }
   }
 
@@ -60,6 +74,12 @@ export class DigitOnlyDirective {
       if (!this.regex.test(newValue)) {
         e.preventDefault();
       }
+    }
+
+    const newValue = Number(this.forecastValue(e.key));
+
+    if (newValue > this.max || newValue < this.min) {
+      e.preventDefault();
     }
   }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,9 @@
   <label for="digit-only">Digit Only input box</label>
   <input id="digit-only" type="text" digitOnly placeholder="000" />
 
+  <label for="digit-only">Digit Only input box between 0 and 100</label>
+  <input id="digit-only" type="text" digitOnly placeholder="000" max="100" min="0"  />
+
   <label for="digit-only-decimal">
     Digit Only input box that allows a <i>decimal point</i>
   </label>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,8 +4,16 @@
   <label for="digit-only">Digit Only input box</label>
   <input id="digit-only" type="text" digitOnly placeholder="000" />
 
-  <label for="digit-only">Digit Only input box between 0 and 100</label>
-  <input id="digit-only" type="text" digitOnly placeholder="000" max="100" min="0"  />
+  <label for="digit-only-min-max">Digit Only input box between 0 and 100</label>
+  <input id="digit-only-min-max" type="text" digitOnly placeholder="Between 0 and 100"  min="0" max="100"  />
+
+  <label for="digit-only-min-max-binding">Digit Only input box between {{ min }} and {{ max }}</label>
+  <input id="digit-only-min-max-binding" type="text" digitOnly placeholder="Between {{ min }} and {{ max }}" [min]="min" [max]="max" />
+
+  Min
+  <input id="min" type="text" digitOnly placeholder="Min" [(ngModel)]="min" />
+  Max
+  <input id="max" type="text" digitOnly placeholder="Max" [(ngModel)]="max" />
 
   <label for="digit-only-decimal">
     Digit Only input box that allows a <i>decimal point</i>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,6 +7,9 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   amount: string;
+  min = 0;
+  max = 10;
+
   watchAmountValue() {
     const value = Number(this.amount);
     this.amount = value.toFixed(2);


### PR DESCRIPTION
It partly fixes https://github.com/changhuixu/ngx-digit-only/issues/23 because implements the logic to prevent from input numbers bigger than `max` and smaller than `min` (only positive numbers because `-` is not allowed without `pattern`).

In other PR could be implemented this and allow negative numbers `-` (w/o patterns)
> If the user types 0 then is it possible to change the value from 0 to 1