### PR TITLE
Fix for Angular's Reactive Form on Firefox

### DIFF
--- a/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
+++ b/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
@@ -137,6 +137,11 @@ export class DigitOnlyDirective implements OnChanges {
       if (this.inputElement.setRangeText) {
         const { selectionStart: start, selectionEnd: end } = this.inputElement;
         this.inputElement.setRangeText(sanitizedContent, start, end, 'end');
+        // Angular's Reactive Form relies on "input" event, but on Firefox, the setRangeText method doesn't trigger it
+        // so we have to trigger it ourself.
+        if (typeof window['InstallTrigger'] !== 'undefined') {
+          this.inputElement.dispatchEvent(new Event('input', { cancelable: true }));
+        }
       } else {
         // Browser does not support setRangeText, e.g. IE
         this.insertAtCursor(this.inputElement, sanitizedContent);
@@ -223,7 +228,7 @@ export class DigitOnlyDirective implements OnChanges {
     return selection
       ? oldValue.replace(selection, key)
       : oldValue.substring(0, selectionStart) +
-          key +
-          oldValue.substring(selectionStart);
+      key +
+      oldValue.substring(selectionStart);
   }
 }


### PR DESCRIPTION
On Firefox, the "setRangeText" method doesn't trigger the "input" event, which Angular's Reactive Form relies on. So, when dropping or pasting value, then getting the value via Reactive Form, only the old value can be retrieved. This PR will fix it.