### PR TITLE
Use beforeinput event to prevent input the Dead keys

### DIFF
--- a/cypress/integration/keyboard-events.spec.ts
+++ b/cypress/integration/keyboard-events.spec.ts
@@ -18,6 +18,13 @@ describe('Keyboard Typing', () => {
       .clear();
   });
 
+  it('should prevent dead keys', () => {
+    cy.get('#digit-only')
+        .type('~~ ~! ~@ ~^')
+        .should('have.value', '')
+        .clear();
+  });
+
   it('should accept a decimal point', () => {
     cy.get('#digit-only-decimal')
       .type('1s2d4d*(,.3')

--- a/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
+++ b/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
@@ -55,6 +55,17 @@ export class DigitOnlyDirective implements OnChanges {
     }
   }
 
+  @HostListener('beforeinput', ['$event'])
+  onBeforeInput(e: InputEvent): any {
+    if (isNaN(Number(e.data))) {
+      if(e.data === this.decimalSeparator) {
+        return; // go on
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  }
+
   @HostListener('keydown', ['$event'])
   onKeyDown(e: KeyboardEvent): any {
     if (


### PR DESCRIPTION
This PR should fix #28 and prevent anyone from entering any Not a Number value except the `decimalSeparator`.