### PR TITLE
Update digit-only.directive.ts

### DIFF
--- a/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
+++ b/projects/uiowa/digit-only/src/lib/digit-only.directive.ts
@@ -31,6 +31,7 @@ export class DigitOnlyDirective implements OnChanges {
   @Input() decimal = false;
   @Input() decimalSeparator = '.';
   @Input() allowNegatives= false;
+  @Input() allowPaste = true;
   @Input() negativeSign = '-';
   @Input() min = -Infinity;
   @Input() max = Infinity;
@@ -132,23 +133,29 @@ export class DigitOnlyDirective implements OnChanges {
       e.preventDefault();
     }
   }
-
+  
   @HostListener('paste', ['$event'])
   onPaste(event: any): void {
-    let pastedInput: string = '';
-    if ((window as { [key: string]: any })['clipboardData']) {
-      // Browser is IE
-      pastedInput = (window as { [key: string]: any })['clipboardData'].getData(
-        'text'
-      );
-    } else if (event.clipboardData && event.clipboardData.getData) {
-      // Other browsers
-      pastedInput = event.clipboardData.getData('text/plain');
-    }
+    if (this.allowPaste === true) {
+      let pastedInput: string = '';
+      if ((window as { [key: string]: any })['clipboardData']) {
+        // Browser is IE
+        pastedInput = (window as { [key: string]: any })['clipboardData'].getData(
+          'text'
+        );
+      } else if (event.clipboardData && event.clipboardData.getData) {
+        // Other browsers
+        pastedInput = event.clipboardData.getData('text/plain');
+      }
 
-    this.pasteData(pastedInput);
-    event.preventDefault();
+      this.pasteData(pastedInput);
+      event.preventDefault();
+    } else {  // this prevents the paste 
+      event.preventDefault();
+      event.stopPropagation();
+    }
   }
+  
 
   @HostListener('drop', ['$event'])
   onDrop(event: DragEvent): void {


### PR DESCRIPTION
Added an allowPaste @Input that can be set to false in markup to prevent pasting into an digitOnly input field.  allowPaste defaults to true.

This was in response to [issue 56 "Can't disable paste"](https://github.com/changhuixu/ngx-digit-only/issues/56).  I tried a couple of the recommendations from stackoverflow without success.  This code change works to prevent pasting, so it might be useful.  